### PR TITLE
Update from v1.1.1 to v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.1 (Mar 24, 2019)
+## 1.1.2 (Mar 24, 2019)
 
 * Updated function to accept a callback
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-organization-members",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-organization-members",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Returns the public members of the user supplied organistation listed on Github.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A previous publish and then unpublish to the npm registry for v1.1.1,
has prevented us from using it. 